### PR TITLE
fix: 프론트 convert 페이지에서 query가 바뀌면 files를 초기화

### DIFF
--- a/front/src/app/convert/page.tsx
+++ b/front/src/app/convert/page.tsx
@@ -31,6 +31,7 @@ function ConvertPageContent() {
     ) {
       router.replace("/");
     }
+    setFiles([]);
   }, [inputExt, outputExt, router]);
 
   const handleConvert = async () => {


### PR DESCRIPTION
- 프론트에서 문서 변환 페이지를 이동했을 때 files가 남아 있어서 이동 시 빈 []을 갖게 설정